### PR TITLE
Fix user count text and add scrollable sidebars

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1680,6 +1680,12 @@ table#user-info th {
     font-size: 11rem;
 }
 
+@media only screen and (max-width: 430px) {
+    .user-count {
+        font-size: 6rem !important;
+    }
+}
+
 .stat-container {
     background: var(--dark-less-more);
     border-radius: 10px;


### PR DESCRIPTION
This fixes two issues, specifically:

- Adding scrollable sidebars when the sidebars start clipping, fixes #68
- Shrink the user count text to `6rem` when the screen reaches `430px`, fixes #71