### PR TITLE
hcaptcha notification is reundant

### DIFF
--- a/templates/signup.html
+++ b/templates/signup.html
@@ -61,13 +61,6 @@
     </form>
 
     <div class="text-muted text-center my-5" id="cookie-footer">
-        {% if config['HCAPTCHA_ENABLED'] %}
-        <small>
-            This site is protected by hCaptcha and its
-            <a href="https://hcaptcha.com/privacy">Privacy Policy</a> and
-            <a href="https://hcaptcha.com/terms">Terms of Service</a> apply.
-        </small> <br/>
-        {% endif %}
         <small>Crabber uses cookies. If you care, you can <a href="{{url_for('static', filename='legal/cookies.txt')}}">read about it here.</a></small>
     </div>
 


### PR DESCRIPTION
didn't notice this before but the "this site is protected by hcaptcha" text at the bottom is redundant, since the hcaptcha is visible and already links to their terms and conditions.

![screenshot](https://egg.lgbt/i/tjycz3f9.png).