### PR TITLE
update username method should match signup restrictions

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -351,7 +351,7 @@ def common_molt_actions() -> Response:
         if validate_email(new_email) or target_user.email == new_email:
             if validate_username(new_username) \
             or target_user.username == new_username:
-                if len(new_username) in range(4, 32):
+                if len(new_username) in range(3, 32):
                     if patterns.username.fullmatch(new_username):
                         if not patterns.only_underscores.fullmatch(new_username):
                             target_user.email = new_email
@@ -365,7 +365,7 @@ def common_molt_actions() -> Response:
                         return show_error('Username must only contain letters, '
                                           'numbers, and underscores')
                 else:
-                    return show_error('Username must be at least 4 characters '
+                    return show_error('Username must be at least 3 characters '
                                       'and less than 32')
             else:
                 return show_error('That username is taken')


### PR DESCRIPTION
the `/signup` route ensures that usernames are between 3 and 32, when updating usernames its restricted between 4 and 32, this makes the username update method match signup, and restrict usernames between 3 and 32.